### PR TITLE
Check for empty token before POSTing logs. Addresses issue #15

### DIFF
--- a/zeus.go
+++ b/zeus.go
@@ -227,6 +227,9 @@ func (zeus *Zeus) PostLogs(logs LogList) (successful int, err error) {
 	if len(logs.Name) == 0 || len(logs.Logs) == 0 {
 		return 0, errors.New("logs is empty")
 	}
+	if len(zeus.Token) == 0 {
+		return 0, errors.new("empty API token")
+	}
 	urlStr := buildUrl(zeus.ApiServ, "logs", zeus.Token, logs.Name)
 
 	jsonStr, err := json.Marshal(logs)


### PR DESCRIPTION
Provide a more exact error when PostLogs executes with an empty Token.
